### PR TITLE
Added row/column index labels and latest-turn position highlighting

### DIFF
--- a/src/balance/Game.java
+++ b/src/balance/Game.java
@@ -16,8 +16,6 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.io.IOException;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -31,7 +29,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
@@ -139,8 +136,8 @@ public class Game extends JFrame implements WindowListener, KeyListener {
 				
 				buttons[i][j].addKeyListener(this);
 
-				constraints.gridx = i + 1;
-				constraints.gridy = j + 1;
+				constraints.gridy = i + 1;
+				constraints.gridx = j + 1;
 				tiles.add(buttons[i][j], constraints);
 			}
 		}
@@ -158,12 +155,12 @@ public class Game extends JFrame implements WindowListener, KeyListener {
 			constraints.gridy = 0;
 			label = new JLabel(Integer.toString(i), JLabel.CENTER);
 			tiles.add(label, constraints);
-			rowLabels[i][0] = label;
+			columnLabels[i][0] = label;
 
 			constraints.gridy = ROWS + 1;
 			label = new JLabel(Integer.toString(i), JLabel.CENTER);
 			tiles.add(label, constraints);
-			rowLabels[i][1] = label;
+			columnLabels[i][1] = label;
 		}
 		
 		// Add left and right columns of numeric labels
@@ -173,12 +170,12 @@ public class Game extends JFrame implements WindowListener, KeyListener {
 			constraints.gridx = 0;
 			label = new JLabel(Integer.toString(j), JLabel.CENTER);
 			tiles.add(label, constraints);
-			columnLabels[j][0] = label;
+			rowLabels[j][0] = label;
 
 			constraints.gridx = COLUMNS + 1;
 			label = new JLabel(Integer.toString(j), JLabel.CENTER);
 			tiles.add(label, constraints);
-			columnLabels[j][1] = label;
+			rowLabels[j][1] = label;
 		}
 		
 		add(tiles, BorderLayout.CENTER);
@@ -894,14 +891,26 @@ public class Game extends JFrame implements WindowListener, KeyListener {
 	{
 		// Eliminate all previous markings
 		
+		Font font = columnLabels[0][0].getFont();
+		
 		for( int i = 0; i < ROWS; ++i ) {
+			// Uncolor
 			columnLabels[i][1].setForeground(null);
 			columnLabels[i][0].setForeground(null);
+			
+			// Unbold
+			columnLabels[i][0].setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
+			columnLabels[i][1].setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
 		}
 		
 		for( int j = 0; j < COLUMNS; ++j ) {
+			// Uncolor
 			rowLabels[j][1].setForeground(null);
 			rowLabels[j][0].setForeground(null);
+			
+			// Unbold
+			rowLabels[j][0].setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
+			rowLabels[j][1].setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
 		}
 		
 		// Set new markings
@@ -910,6 +919,11 @@ public class Game extends JFrame implements WindowListener, KeyListener {
 		rowLabels[row][1].setForeground(Color.RED);
 		columnLabels[column][0].setForeground(Color.RED);
 		columnLabels[column][1].setForeground(Color.RED);
+
+		rowLabels[row][0].setFont(font.deriveFont(font.getStyle() | Font.BOLD));
+		rowLabels[row][1].setFont(font.deriveFont(font.getStyle() | Font.BOLD));
+		columnLabels[column][0].setFont(font.deriveFont(font.getStyle() | Font.BOLD));
+		columnLabels[column][1].setFont(font.deriveFont(font.getStyle() | Font.BOLD));
 	}
 
 	@Override

--- a/src/balance/Game.java
+++ b/src/balance/Game.java
@@ -1,5 +1,6 @@
 package balance;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -33,6 +34,10 @@ public class Game extends JFrame implements WindowListener {
 	private static final long serialVersionUID = -8705064841297440045L;
 	public static final int ROWS = 12;
 	public static final int COLUMNS = 12;
+
+	// References for row/column index labels
+	JLabel[][] rowLabels = new JLabel[ROWS][2];
+	JLabel[][] columnLabels = new JLabel[COLUMNS][2];
 	
 	private Square[][] board = new Square[ROWS][COLUMNS]; 
 	private Square[][] swap = new Square[ROWS][COLUMNS];
@@ -104,8 +109,8 @@ public class Game extends JFrame implements WindowListener {
 		
 		JPanel tiles = new JPanel();
 		tiles.setLayout(new GridBagLayout());
-		final Grass GRASS = new Grass();
 		GridBagConstraints constraints = new GridBagConstraints();
+		final Grass GRASS = new Grass();
 	
 		for( int i = 0; i < ROWS; ++i ) {
 			for( int j = 0; j < COLUMNS; ++j ) {
@@ -134,15 +139,21 @@ public class Game extends JFrame implements WindowListener {
 		constraints.ipadx = 5;
 		constraints.ipady = 5;
 		
+		JLabel label;
+		
 		// Add top and bottom rows of numeric labels
 		for( int i = 0; i < COLUMNS; ++i ) {
 			constraints.gridx = i + 1;
 			
 			constraints.gridy = 0;
-			tiles.add(new JLabel(Integer.toString(i), JLabel.CENTER), constraints);
+			label = new JLabel(Integer.toString(i), JLabel.CENTER);
+			tiles.add(label, constraints);
+			rowLabels[i][0] = label;
 
 			constraints.gridy = ROWS + 1;
-			tiles.add(new JLabel(Integer.toString(i), JLabel.CENTER), constraints);
+			label = new JLabel(Integer.toString(i), JLabel.CENTER);
+			tiles.add(label, constraints);
+			rowLabels[i][1] = label;
 		}
 		
 		// Add left and right columns of numeric labels
@@ -150,10 +161,14 @@ public class Game extends JFrame implements WindowListener {
 			constraints.gridy = j + 1;
 			
 			constraints.gridx = 0;
-			tiles.add(new JLabel(Integer.toString(j), JLabel.CENTER), constraints);
+			label = new JLabel(Integer.toString(j), JLabel.CENTER);
+			tiles.add(label, constraints);
+			columnLabels[j][0] = label;
 
 			constraints.gridx = COLUMNS + 1;
-			tiles.add(new JLabel(Integer.toString(j), JLabel.CENTER), constraints);
+			label = new JLabel(Integer.toString(j), JLabel.CENTER);
+			tiles.add(label, constraints);
+			columnLabels[j][1] = label;
 		}
 		
 		add(tiles, BorderLayout.CENTER);
@@ -634,6 +649,7 @@ public class Game extends JFrame implements WindowListener {
 			Player player = player1Turn ? player1 : player2;
 			Player otherPlayer = player1Turn ? player2 : player1;
 			
+			markRowColumn(row, column);
 			addMessage(player.getName() + " " + move.pastVerb() + " " + move + " at (" + row + "," + column + ")" );
 			 			
 			if( otherPlayer instanceof NetworkPlayer ) {
@@ -830,6 +846,32 @@ public class Game extends JFrame implements WindowListener {
 
 	private void addMessage(String text) {
 		messages.setText(messages.getText() + "\n" + text);
+	}
+	
+	/**
+	 * Highlights the indices alongside the rows and columns requested.
+	 * Removes all previous highlights.
+	 */
+	private void markRowColumn(int row, int column)
+	{
+		// Eliminate all previous markings
+		
+		for( int i = 0; i < ROWS; ++i ) {
+			columnLabels[i][1].setForeground(null);
+			columnLabels[i][0].setForeground(null);
+		}
+		
+		for( int j = 0; j < COLUMNS; ++j ) {
+			rowLabels[j][1].setForeground(null);
+			rowLabels[j][0].setForeground(null);
+		}
+		
+		// Set new markings
+		
+		rowLabels[row][0].setForeground(Color.RED);
+		rowLabels[row][1].setForeground(Color.RED);
+		columnLabels[column][0].setForeground(Color.RED);
+		columnLabels[column][1].setForeground(Color.RED);
 	}
 
 	@Override

--- a/src/balance/Game.java
+++ b/src/balance/Game.java
@@ -3,6 +3,8 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -100,11 +102,12 @@ public class Game extends JFrame implements WindowListener {
 		
 		initializeAlignments(alignment1, alignment2);
 		
-		JPanel tiles = new JPanel();	
-		tiles.setLayout(new GridLayout(ROWS, COLUMNS));
+		JPanel tiles = new JPanel();
+		tiles.setLayout(new GridBagLayout());
 		final Grass GRASS = new Grass();
+		GridBagConstraints constraints = new GridBagConstraints();
 	
-		for( int i = 0; i < ROWS; ++i )
+		for( int i = 0; i < ROWS; ++i ) {
 			for( int j = 0; j < COLUMNS; ++j ) {
 				final int row = i;
 				final int column = j;
@@ -121,8 +124,37 @@ public class Game extends JFrame implements WindowListener {
 						clickButton( row, column );						
 					}});
 				
-				tiles.add(buttons[i][j]);
+				constraints.gridx = i + 1;
+				constraints.gridy = j + 1;
+				tiles.add(buttons[i][j], constraints);
 			}
+		}
+		
+		// Provide a little padding for the labels
+		constraints.ipadx = 5;
+		constraints.ipady = 5;
+		
+		// Add top and bottom rows of numeric labels
+		for( int i = 0; i < COLUMNS; ++i ) {
+			constraints.gridx = i + 1;
+			
+			constraints.gridy = 0;
+			tiles.add(new JLabel(Integer.toString(i), JLabel.CENTER), constraints);
+
+			constraints.gridy = ROWS + 1;
+			tiles.add(new JLabel(Integer.toString(i), JLabel.CENTER), constraints);
+		}
+		
+		// Add left and right columns of numeric labels
+		for( int j = 0; j < ROWS; ++j ) {
+			constraints.gridy = j + 1;
+			
+			constraints.gridx = 0;
+			tiles.add(new JLabel(Integer.toString(j), JLabel.CENTER), constraints);
+
+			constraints.gridx = COLUMNS + 1;
+			tiles.add(new JLabel(Integer.toString(j), JLabel.CENTER), constraints);
+		}
 		
 		add(tiles, BorderLayout.CENTER);
 		


### PR DESCRIPTION
Currently, the previous player's move is listed in the message area with the coordinates `(x, y)` at which it took place. I found it surprisingly difficult to locate a specific tile on the board given a pair of coordinates, so I've added numerical indices along all sides of the board to make this easier.

Going even further, the labels of the rows and columns in which the most recent move took place will now be colored red and highlighted.
